### PR TITLE
Fix Issue with Trailing Commas in Commands

### DIFF
--- a/Jekyll.sublime-commands
+++ b/Jekyll.sublime-commands
@@ -1,23 +1,23 @@
 [
     {
         "caption": "Jekyll: New post",
-        "command": "jekyll_new_post",
+        "command": "jekyll_new_post"
     },
     {
         "caption": "Jekyll: New draft",
-        "command": "jekyll_new_draft",
+        "command": "jekyll_new_draft"
     },
     {
         "caption": "Jekyll: Open post...",
-        "command": "jekyll_open_post",
+        "command": "jekyll_open_post"
     },
     {
         "caption": "Jekyll: Open draft...",
-        "command": "jekyll_open_draft",
+        "command": "jekyll_open_draft"
     },
     {
         "caption": "Jekyll: Promote draft to post...",
-        "command": "jekyll_promote_draft",
+        "command": "jekyll_promote_draft"
     },
     {
         "caption": "Jekyll: Insert current date",


### PR DESCRIPTION
Fixes following error:
`Error loading commands: Error trying to parse file: Trailing comma before closing bracket in ~/Library/Application Support/Sublime Text 2/Packages/Jekyll/Jekyll.sublime-commands:5:5`
