### PR TITLE
add import shutil

### DIFF
--- a/jekyll.py
+++ b/jekyll.py
@@ -9,6 +9,8 @@ import sys
 import traceback
 import uuid
 
+import shutil
+
 from datetime import datetime
 from functools import wraps
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
The following error occured when promoting a draft to post: 
global name 'shutil' is not defined (Line 875: shutil.move(f, fpath))

add import shutil in jekyll.py to fix this error