### PR TITLE
Fixes to address 23maverick23/sublime-jekyll/#92

### DIFF
--- a/docs/commands.rst
+++ b/docs/commands.rst
@@ -128,11 +128,11 @@ Insert current datetime
     :Description: Inserts the current datetime at the cursor using the format specified by the ``jekyll_datetime_format`` setting.
 
 
-Insert upload
-^^^^^^^^^^^^^
+Insert upload tag
+^^^^^^^^^^^^^^^^^
 
     :Command: ``jekyll_insert_upload``
-    :Description: Brings up a quick panel for choosing an existing file in your ``uploads`` directory, and adds a pre-formatted link at the cursor.
+    :Description: Brings up a quick panel allowing you to choose an existing file from your ``jekyll_uploads_path`` directory, and creates a pre-formatted link at the cursor. This won't move the selected file, nor will it check if the realtive URL it creates points to an actual file.
 
 
 Jekyll Utility

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -61,13 +61,13 @@ User Settings
 ``jekyll_uploads_baseurl``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-    :Default: ``{{ site.baseurl }}``
-    :Description: This string value should represent the **baseurl** for the uploads directory. For example, if your uploads directory is ``uploads`` and you have an image called ``image.png``, the output of inserting the image in your post would be ``{{ uploads_baseurl }}/uploads/image.png``, with ``{{ uploads_baseurl }}`` replace by its value.
+    :Default: ``{{site.baseurl}}``
+    :Description: This string value should represent the **baseurl** for the uploads directory of your site. For example, if your uploads directory is ``/uploads`` and you have an image called ``image.png``, the output of inserting the image in your post with the ``Insert upload tag`` command would be ``{{ uploads_baseurl }}/uploads/image.png``, with ``{{ uploads_baseurl }}`` replaced by its value.
 
 
 .. note::
 
-    If you wish to have an absolute link and you have ``url`` defined in your Jekyll ``config.yml`` file, then you can set the value to ``{{ site.url }}/{{ site.baseurl }}``.
+    If you wish to have an absolute link and you have ``url`` defined in your Jekyll ``config.yml`` file, then you can set the value to ``{{site.url}}/{{site.baseurl}}``.
 
 
 ``jekyll_default_markup``
@@ -144,7 +144,7 @@ For per-project settings, make sure you add your Jekyll settings correctly to yo
 .. code-block:: python
 
     # some-file.sublime-settings
-    
+
     {
         "folders":
         [

--- a/jekyll.py
+++ b/jekyll.py
@@ -1200,8 +1200,9 @@ class JekyllInsertUpload(sublime_plugin.TextCommand):
         uploads_path = get_setting(self.view, 'jekyll_uploads_path')
         uploads_baseurl = get_setting(self.view, 'jekyll_uploads_baseurl')
         relative_path = os.path.relpath(args["path"], os.path.dirname(uploads_path))
+        relative_path = relative_path.replace(os.sep, '/')
 
-        # check if image
+        # build image URL
         link_str = "{0}[{1}]({2}/{3})".format(
             '!' if imghdr.what(args["path"]) is not None else '',
             '${1:' + args["name"] + '}', uploads_baseurl, relative_path


### PR DESCRIPTION
Fixes #92.

Changes proposed in this pull request:

- Always make "Insert Upload Tag" path use forward slashes
- Update the relevant commands docs page
- Update the relevant default settings to avoid a Sublime markdown syntax error indication